### PR TITLE
Upgrade ProtocolLib to v4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.8.0-SNAPSHOT</version>
+            <version>4.8.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
`4.8.0-SNAPSHOT` no longer exists in the repository, resulting in Maven failing to download the dependency.