### PR TITLE
Fix animations flickering when multiple animations are available in a single `BakedAnimationTree` node

### DIFF
--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/BakedAnimationEntity.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/BakedAnimationEntity.java
@@ -141,7 +141,14 @@ public class BakedAnimationEntity extends CompositeEntity {
             AnimationJob expected = new AnimationJob(animationTree.getAnimation(this),null,0);
 //Logger.getGlobal().info("Expected: "+(expected == null?"none":expected.getName()));
             if(expected.getAnimation() != null
-                    && (currentAnimation== null || currentAnimation.getAnimation()!=expected.getAnimation())) {
+                    && (
+                            currentAnimation == null
+                            || currentAnimation.getAnimation() == null
+                            // If current animation is at the last frame, allow switching to another random animation
+                            || currentAnimation.getAnimation().isAtLastFrame()
+                            // And always switch if we're trying to switch to a completely different animation
+                            || !expected.getAnimation().getAnimationName().equals(currentAnimation.getAnimation().getAnimationName())
+                    )) {
 //Logger.getGlobal().info("Switch from: "+(currentAnimation == null?"none":currentAnimation.getName()));
                 if(!manualOverride && instantAnimationSwitching
                                    && callAnimationChangeEvent(currentAnimation,expected)) {

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/BakedAnimationEntity.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/BakedAnimationEntity.java
@@ -85,6 +85,14 @@ public class BakedAnimationEntity extends CompositeEntity {
 //Logger.getGlobal().info("DataFile: "+factory.getDataFile());
                     animationKey = entry.getKey();
                 }
+                // Ignore integers if they're the last part of the path - those are used to distinguish different animations with the same key
+                int lastDot = animationKey.lastIndexOf('.');
+                if (lastDot > 0) {
+                    String lastKeyPart = animationKey.substring(lastDot + 1);
+                    if (lastKeyPart.matches("^\\d+$")) {
+                        animationKey = animationKey.substring(0, lastDot);
+                    }
+                }
 //Logger.getGlobal().info("AnimationKey: "+animationKey);
                 animationTree.addAnimation(animationKey, BakedAnimation.loadAnimation(entry.getValue().getAsJsonObject(),
                         itemMaterial, this, animationKey));

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/BakedAnimationEntity.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/BakedAnimationEntity.java
@@ -85,17 +85,18 @@ public class BakedAnimationEntity extends CompositeEntity {
 //Logger.getGlobal().info("DataFile: "+factory.getDataFile());
                     animationKey = entry.getKey();
                 }
+                String animationName = animationKey;
                 // Ignore integers if they're the last part of the path - those are used to distinguish different animations with the same key
-                int lastDot = animationKey.lastIndexOf('.');
+                int lastDot = animationName.lastIndexOf('.');
                 if (lastDot > 0) {
-                    String lastKeyPart = animationKey.substring(lastDot + 1);
+                    String lastKeyPart = animationName.substring(lastDot + 1);
                     if (lastKeyPart.matches("^\\d+$")) {
-                        animationKey = animationKey.substring(0, lastDot);
+                        animationName = animationName.substring(0, lastDot);
                     }
                 }
 //Logger.getGlobal().info("AnimationKey: "+animationKey);
-                animationTree.addAnimation(animationKey, BakedAnimation.loadAnimation(entry.getValue().getAsJsonObject(),
-                        itemMaterial, this, animationKey));
+                animationTree.addAnimation(animationName, BakedAnimation.loadAnimation(entry.getValue().getAsJsonObject(),
+                        itemMaterial, this, animationKey, animationName));
             });
 //Logger.getGlobal().info("Animation loading: "+(System.currentTimeMillis()-start));
         } catch (IOException | JsonParseException | IllegalStateException e) {

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/animation/BakedAnimation.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/animation/BakedAnimation.java
@@ -28,9 +28,15 @@ public class BakedAnimation {
 
     private final String name;
 
-    public BakedAnimation(BakedAnimationEntity entity, BakedAnimationType type, String name, String next, int interval) {
+    /**
+     * The non-unique name of the animation this instance represents.
+     */
+    private final String animationName;
+
+    public BakedAnimation(BakedAnimationEntity entity, BakedAnimationType type, String name, String animationName, String next, int interval) {
         this.entity = entity;
         this.name = name;
+        this.animationName = animationName;
         this.type = type;
         this.next = next;
         this.interval = interval;
@@ -81,6 +87,10 @@ public class BakedAnimation {
         return name;
     }
 
+    public String getAnimationName() {
+        return animationName;
+    }
+
     public String getNext() {
         return next;
     }
@@ -98,7 +108,7 @@ public class BakedAnimation {
         }
     }
 
-    public static BakedAnimation loadAnimation(JsonObject data, Material itemMaterial, BakedAnimationEntity entity, String name) {
+    public static BakedAnimation loadAnimation(JsonObject data, Material itemMaterial, BakedAnimationEntity entity, String name, String animationName) {
         Map<String, Integer> states = new HashMap<>();
         BakedAnimationType type;
         try {
@@ -108,7 +118,7 @@ public class BakedAnimation {
         }
         int interval = (data.get("interval") == null? 1 : data.get("interval").getAsInt());
         String next = (data.has("next")?data.get("next").getAsString():null);
-        BakedAnimation animation = new BakedAnimation(entity, type, name, next, interval);
+        BakedAnimation animation = new BakedAnimation(entity, type, name, animationName, next, interval);
         JsonArray frameData = data.get("frames").getAsJsonArray();
 //long start = System.currentTimeMillis();
         for(int i = 0; i< frameData.size(); i++) {
@@ -118,8 +128,8 @@ public class BakedAnimation {
         return animation;
     }
 
-    public BakedAnimation getReverse(String name) {
-        BakedAnimation reverse = new BakedAnimation(entity, type, name, next, interval);
+    public BakedAnimation getReverse(String name, String animationName) {
+        BakedAnimation reverse = new BakedAnimation(entity, type, name, animationName, next, interval);
         for(int i = frames.size()-1; i >= 0; i--) {
             reverse.addFrame(frames.get(i));
         }

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/animation/BakedAnimationTree.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/animation/BakedAnimationTree.java
@@ -25,10 +25,6 @@ public class BakedAnimationTree {
 
     public void addAnimation(String path, BakedAnimation animation) {
         String[] pathArray = path.split("\\.");
-        try {
-            Integer.parseInt(pathArray[pathArray.length-1]);
-            pathArray = Arrays.copyOf(pathArray, pathArray.length-1);
-        } catch (NumberFormatException ignore) {}
         addAnimation(pathArray,animation);
         for(int i = 0; i < pathArray.length; i++) {
             try{

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/animation/BakedAnimationTree.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/animation/BakedAnimationTree.java
@@ -50,7 +50,9 @@ public class BakedAnimationTree {
 
     private void addBackwardFallbackAnimation(String[] path, BakedAnimation animation) {
         if(getAnimation(path) == null) {
-            addAnimation(path, animation.getReverse(Joiner.on('.').join(path)));
+            String name = Joiner.on('.').join(path);
+            // FIXME: This will generate non-unique names for the reverse animations. I do not care.
+            addAnimation(path, animation.getReverse(name, name));
 //Logger.getGlobal().info("adding fallback: "+Joiner.on('.').join(path));
         }
     }


### PR DESCRIPTION
In theory this doesn't break anything, but what the tree paths and animation names are intended to be gave me a headache.