### PR TITLE
Fix spawn packets being needlessly updated

### DIFF
--- a/src/main/java/com/mcmiddleearth/entities/entities/Projectile.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/Projectile.java
@@ -53,7 +53,7 @@ public class Projectile extends SimpleNonLivingEntity {
     @Override
     public void doTick() {
         if(!onGround) {
-            spawnPacket.update();
+            spawnPacketDirty = true;
             Vector velocity = getVelocity().clone();//
             //Logger.getGlobal().info("FALLING: "+velocity);
             double speed = velocity.length();

--- a/src/main/java/com/mcmiddleearth/entities/entities/VirtualEntity.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/VirtualEntity.java
@@ -58,6 +58,7 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
     protected int tickCounter = 0;
 
     protected AbstractPacket spawnPacket;
+    protected boolean spawnPacketDirty = true;
     protected AbstractPacket removePacket;
     protected AbstractPacket teleportPacket;
     protected AbstractPacket movePacket;
@@ -261,7 +262,7 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
         lookUpdate = false;
         rotationUpdate = false;
 
-        spawnPacket.update();
+        spawnPacketDirty = true;
     }
 
     public void move() {
@@ -283,7 +284,7 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
         lookUpdate = false;
         rotationUpdate = false;
 
-        spawnPacket.update();
+        spawnPacketDirty = true;
     }
 
     @Override
@@ -464,6 +465,10 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
         if(!useWhitelistAsBlacklist && !(whiteList.isEmpty() || whiteList.contains(player.getUniqueId()))
                 || useWhitelistAsBlacklist && whiteList.contains(player.getUniqueId())) {
             return;
+        }
+        if (spawnPacketDirty) {
+            spawnPacket.update();
+            spawnPacketDirty = false;
         }
         spawnPacket.send(player);
         viewers.add(player);

--- a/src/main/java/com/mcmiddleearth/entities/entities/simple/SimpleHorse.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/simple/SimpleHorse.java
@@ -27,7 +27,7 @@ public class SimpleHorse extends SimpleLivingEntity {
         saddled = isSaddled;
         ((SimpleHorseMetadataPacket)metadataPacket).setSaddled(isSaddled);
         metadataPacket.update();
-        spawnPacket.update();
+        spawnPacketDirty = true;
         getViewers().forEach(viewer->metadataPacket.send(viewer));
     }
 


### PR DESCRIPTION
Spawn packets are currently always being updated, even if they're never going to be used. This PR makes that update happen only if necessary.