### PR TITLE
Dependency cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,16 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>org.apache.commons:commons-math3</include>
+                            <!-- Used internally for building messages and included because it's not available on some platforms anymore. Should be removed in favor of kyori Adventure API. -->
+                            <include>net.md-5:bungeecord-chat</include>
+                            <include>com.mcmiddleearth:MCME-CommandParser</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
             </plugin>
         </plugins>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -101,11 +101,6 @@
             <version>1.0.1</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.uuid</groupId>
-            <artifactId>java-uuid-generator</artifactId>
-            <version>4.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.mcmiddleearth</groupId>
             <artifactId>MCME-CommandParser</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>

--- a/src/main/java/com/mcmiddleearth/entities/command/BukkitCommandSender.java
+++ b/src/main/java/com/mcmiddleearth/entities/command/BukkitCommandSender.java
@@ -4,9 +4,9 @@ import com.mcmiddleearth.command.McmeCommandSender;
 import com.mcmiddleearth.entities.api.McmeEntityType;
 import com.mcmiddleearth.entities.api.VirtualEntityFactory;
 import com.mcmiddleearth.entities.entities.McmeEntity;
-import net.md_5.bungee.api.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.ComponentBuilder;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 
@@ -34,7 +34,17 @@ public class BukkitCommandSender implements McmeCommandSender {
 
     @Override
     public void sendMessage(BaseComponent[] baseComponents) {
-        sender.sendMessage(new ComponentBuilder("[Entities] ").color(ChatColor.AQUA).append(baseComponents[0]).create());
+        sender.sendMessage(Component.text("[Entities] ", NamedTextColor.AQUA).append(Component.text(baseComponents[0].toLegacyText())));
+    }
+
+    @Override
+    public void sendMessage(String message) {
+        sender.sendMessage(Component.text("[Entities] ", NamedTextColor.AQUA).append(Component.text(message)));
+    }
+
+    @Override
+    public void sendError(String message) {
+        sender.sendMessage(Component.text("[Entities] ", NamedTextColor.AQUA).append(Component.text(message, NamedTextColor.RED)));
     }
 
     public CommandSender getCommandSender() {

--- a/src/main/java/com/mcmiddleearth/entities/util/UuidGenerator.java
+++ b/src/main/java/com/mcmiddleearth/entities/util/UuidGenerator.java
@@ -1,9 +1,5 @@
 package com.mcmiddleearth.entities.util;
 
-import com.fasterxml.uuid.EthernetAddress;
-import com.fasterxml.uuid.Generators;
-
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -38,14 +34,6 @@ public class UuidGenerator {
         long mostSig = (timeForUuidIn100Nanos & 0xFFFFFFFFFFFF0000L) + version + least12SignificatBitOfTime;
 
         UUID uuid = new UUID(mostSig,leastSig);
-Logger.getGlobal().info("UUID version: "+uuid.version());
-        return uuid;
-    }
-
-    public static UUID slow_getRandomV2() {
-        //long nul = 0;
-        //return new UUID(nul,nul);
-        UUID uuid = Generators.timeBasedGenerator(EthernetAddress.fromInterface()).generate();
 Logger.getGlobal().info("UUID version: "+uuid.version());
         return uuid;
     }


### PR DESCRIPTION
- Upgrade MCME-CommandParser from 1.0 to 1.0.1, to avoid conflicts with MCME-Scripts which uses 1.0.1. Not a perfect solution, but prevents issues for now. A better solution might to use MCME-CommandParser from MCME-Entities, or relocating the dependency for both plugins.

- Removes unused dependency on java-uuid-generator.

- Limits dependencies which get shadowed to what's absolutely necessary. This could cause missing dependency issues on some platforms, but it seems to work fine on both Magma 1.16 and Paper 1.18. It reduces the plugin size from 4.8MB to 1.8MB.