### PR TITLE
Reuse ProtocolLib objects in BoneMetaPacket

### DIFF
--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
@@ -1,5 +1,6 @@
 package com.mcmiddleearth.entities.protocol.packets.composite;
 
+import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import com.mcmiddleearth.entities.entities.composite.bones.Bone;
 import com.mcmiddleearth.entities.protocol.EntityMeta;
@@ -7,50 +8,46 @@ import org.bukkit.entity.Player;
 
 public class BoneInitPacket extends BoneMetaPacket {
 
-    WrappedDataWatcher watcher = new WrappedDataWatcher();
-
     public BoneInitPacket(Bone bone) {
         super(bone,0);
 
 //long start = System.currentTimeMillis();
-        writeInit(watcher);
-//Logger.getGlobal().info("Init: "+(System.currentTimeMillis()-start));
-
-        writeHeadPose(watcher);
-//Logger.getGlobal().info("Pose: "+(System.currentTimeMillis()-start));
 
         writeHeadItem();
 //Logger.getGlobal().info("item: "+(System.currentTimeMillis()-start));
 
-        posePacket.getWatchableCollectionModifier().write(0,watcher.getWatchableObjects());
 //Logger.getGlobal().info("Bone creation: "+(System.currentTimeMillis()-start));
+    }
+
+    @Override
+    protected PacketContainer createHeadPosePacket(WrappedDataWatcher dataWatcher) {
+        PacketContainer packet = super.createHeadPosePacket(dataWatcher);
+
+        WrappedDataWatcher.WrappedDataWatcherObject invisibility = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ENTITY_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
+        dataWatcher.setObject(invisibility, Byte.decode("0x20"),false);
+        WrappedDataWatcher.WrappedDataWatcherObject silent = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ENTITY_SILENT,WrappedDataWatcher.Registry.get(Boolean.class));
+        dataWatcher.setObject(silent, true,false);
+        WrappedDataWatcher.WrappedDataWatcherObject gravity = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ENTITY_NO_GRAVITY,WrappedDataWatcher.Registry.get(Boolean.class));
+        dataWatcher.setObject(gravity, false,false);
+        WrappedDataWatcher.WrappedDataWatcherObject base = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ARMOR_STAND_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
+        dataWatcher.setObject(base, Byte.decode("0x08"),false);
+
+        return packet;
     }
 
     @Override
     public void update() {
         if(bone.isHasHeadPoseUpdate()) {
-            writeHeadPose(watcher);
-            posePacket.getWatchableCollectionModifier().write(0,watcher.getWatchableObjects());
+            updateHeadPose(getHeadPose());
         }
 
         if(bone.isHasItemUpdate()) {
             writeHeadItem();
         }
-    }
-
-    protected void writeInit(WrappedDataWatcher watcher) {
-        WrappedDataWatcher.WrappedDataWatcherObject invisibility = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ENTITY_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
-        watcher.setObject(invisibility, Byte.decode("0x20"),false);
-        WrappedDataWatcher.WrappedDataWatcherObject silent = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ENTITY_SILENT,WrappedDataWatcher.Registry.get(Boolean.class));
-        watcher.setObject(silent, true,false);
-        WrappedDataWatcher.WrappedDataWatcherObject gravity = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ENTITY_NO_GRAVITY,WrappedDataWatcher.Registry.get(Boolean.class));
-        watcher.setObject(gravity, false,false);
-        WrappedDataWatcher.WrappedDataWatcherObject base = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ARMOR_STAND_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
-        watcher.setObject(base, Byte.decode("0x08"),false);
     }
 
     @Override


### PR DESCRIPTION
Constantly creating new instances is expensive - it does a lot behind the scenes. Reusing the objects makes updates noticeably faster when many baked entities are spawned.