### PR TITLE
Make calling packet update method every tick optional

### DIFF
--- a/src/main/java/com/mcmiddleearth/entities/entities/VirtualEntity.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/VirtualEntity.java
@@ -10,7 +10,6 @@ import com.mcmiddleearth.entities.ai.movement.MovementEngine;
 import com.mcmiddleearth.entities.api.*;
 import com.mcmiddleearth.entities.entities.attributes.VirtualAttributeFactory;
 import com.mcmiddleearth.entities.entities.composite.SpeechBalloonEntity;
-import com.mcmiddleearth.entities.entities.composite.WingedFlightEntity;
 import com.mcmiddleearth.entities.entities.composite.bones.SpeechBalloonLayout;
 import com.mcmiddleearth.entities.events.events.McmeEntityDamagedEvent;
 import com.mcmiddleearth.entities.events.events.McmeEntityDeathEvent;
@@ -22,6 +21,7 @@ import com.mcmiddleearth.entities.events.events.virtual.VirtualEntityTalkEvent;
 import com.mcmiddleearth.entities.exception.InvalidDataException;
 import com.mcmiddleearth.entities.exception.InvalidLocationException;
 import com.mcmiddleearth.entities.inventory.McmeInventory;
+import com.mcmiddleearth.entities.protocol.packets.AbstractMovePacket;
 import com.mcmiddleearth.entities.protocol.packets.AbstractPacket;
 import com.mcmiddleearth.entities.util.UuidGenerator;
 import org.bukkit.Location;
@@ -33,12 +33,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.logging.Logger;
 
 public abstract class VirtualEntity implements McmeEntity, Attributable {
 
@@ -61,7 +59,7 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
     protected boolean spawnPacketDirty = true;
     protected AbstractPacket removePacket;
     protected AbstractPacket teleportPacket;
-    protected AbstractPacket movePacket;
+    protected AbstractMovePacket movePacket;
     protected AbstractPacket statusPacket;
     private Location location;
 
@@ -274,6 +272,8 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
 //if(!(this instanceof Projectile)) Logger.getGlobal().info("location new: "+ getLocation().getX()+" "+getLocation().getY()+" "+getLocation().getZ());
         boundingBox.setLocation(location);
 
+        movePacket.markMovementDirty(AbstractMovePacket.MoveType.getEntityMoveType(this));
+
         if (hasViewers()) {
             if ((tickCounter % updateInterval == updateRandom)) {
                 teleportPacket.update();
@@ -311,6 +311,7 @@ public abstract class VirtualEntity implements McmeEntity, Attributable {
         headYaw = yaw;
         headPitch = pitch;
         lookUpdate = true;
+        movePacket.markMovementDirty(AbstractMovePacket.MoveType.HEAD);
     }
 
     @Override

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/bones/BoneThreeAxis.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/bones/BoneThreeAxis.java
@@ -6,8 +6,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
 
-import java.util.logging.Logger;
-
 public class BoneThreeAxis extends BoneTwoAxis {
 
     private float roll;
@@ -45,6 +43,7 @@ public class BoneThreeAxis extends BoneTwoAxis {
     Logger.getGlobal().info("velo: "+velocity);
 }*/
 
+        afterMoveUpdate();
     }
 
     public void teleport() {

--- a/src/main/java/com/mcmiddleearth/entities/entities/composite/bones/BoneTwoAxis.java
+++ b/src/main/java/com/mcmiddleearth/entities/entities/composite/bones/BoneTwoAxis.java
@@ -1,23 +1,10 @@
 package com.mcmiddleearth.entities.entities.composite.bones;
 
-import com.mcmiddleearth.entities.ai.goal.Goal;
-import com.mcmiddleearth.entities.ai.movement.EntityBoundingBox;
-import com.mcmiddleearth.entities.api.ActionType;
-import com.mcmiddleearth.entities.api.McmeEntityType;
-import com.mcmiddleearth.entities.api.MovementSpeed;
-import com.mcmiddleearth.entities.api.MovementType;
-import com.mcmiddleearth.entities.entities.McmeEntity;
 import com.mcmiddleearth.entities.entities.composite.CompositeEntity;
-import com.mcmiddleearth.entities.protocol.packets.*;
 import com.mcmiddleearth.entities.util.RotationMatrix;
-import com.mcmiddleearth.entities.util.UuidGenerator;
-import org.bukkit.Location;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
-
-import java.util.Set;
-import java.util.UUID;
 
 public class BoneTwoAxis extends Bone {//implements McmeEntity {
 
@@ -124,6 +111,7 @@ public class BoneTwoAxis extends Bone {//implements McmeEntity {
 
         velocity = parent.getVelocity().clone().add(shift);
 
+        afterMoveUpdate();
     }
 
     public void teleport() {

--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/AbstractMovePacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/AbstractMovePacket.java
@@ -1,0 +1,59 @@
+package com.mcmiddleearth.entities.protocol.packets;
+
+import com.mcmiddleearth.entities.entities.McmeEntity;
+import org.bukkit.util.Vector;
+
+public abstract class AbstractMovePacket extends AbstractPacket {
+    /**
+     * Notifies the packet of a certain part of their movement state being dirty, meaning it should be updated in a future update.
+     */
+    public abstract void markMovementDirty(MoveType moveType);
+
+    public enum MoveType {
+        STAND(false, false, false),
+        MOVE(true, false, false),
+        MOVE_LOOK(true, true, false),
+        LOOK(false, true, false),
+        HEAD(false, false, true),
+        ;
+
+        private final boolean updatesMove;
+        private final boolean updatesLook;
+        private final boolean updatesHead;
+
+        private MoveType(boolean updatesMove, boolean updatesLook, boolean updatesHead) {
+            this.updatesMove = updatesMove;
+            this.updatesLook = updatesLook;
+            this.updatesHead = updatesHead;
+        }
+
+        public boolean updatesMove() {
+            return updatesMove;
+        }
+
+        public boolean updatesLook() {
+            return updatesLook;
+        }
+
+        public boolean updatesHead() {
+            return updatesHead;
+        }
+
+        public static MoveType getEntityMoveType(McmeEntity entity) {
+            Vector velocity = entity.getVelocity();
+            if(velocity.getX() == 0 && velocity.getY() == 0 && velocity.getZ() == 0) {
+                if(entity.hasLookUpdate() || entity.hasRotationUpdate()) {
+                    return MoveType.LOOK;
+                } else {
+                    return MoveType.STAND;
+                }
+            } else {
+                if(entity.hasLookUpdate() || entity.hasRotationUpdate()) {
+                    return MoveType.MOVE_LOOK;
+                } else {
+                    return MoveType.MOVE;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/ArrowMovePacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/ArrowMovePacket.java
@@ -2,10 +2,14 @@ package com.mcmiddleearth.entities.protocol.packets;
 
 import org.bukkit.entity.Player;
 
-public class ArrowMovePacket extends AbstractPacket {
+public class ArrowMovePacket extends AbstractMovePacket {
 
     @Override
     public void send(Player recipient) {
 
+    }
+
+    @Override
+    public void markMovementDirty(MoveType moveType) {
     }
 }

--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
@@ -1,5 +1,6 @@
 package com.mcmiddleearth.entities.protocol.packets.composite;
 
+import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import com.mcmiddleearth.entities.entities.composite.bones.Bone;
 import com.mcmiddleearth.entities.protocol.EntityMeta;
@@ -7,50 +8,46 @@ import org.bukkit.entity.Player;
 
 public class BoneInitPacket extends BoneMetaPacket {
 
-    WrappedDataWatcher watcher = new WrappedDataWatcher();
-
     public BoneInitPacket(Bone bone) {
         super(bone,0);
 
 //long start = System.currentTimeMillis();
-        writeInit(watcher);
-//Logger.getGlobal().info("Init: "+(System.currentTimeMillis()-start));
-
-        writeHeadPose(watcher);
-//Logger.getGlobal().info("Pose: "+(System.currentTimeMillis()-start));
 
         writeHeadItem();
 //Logger.getGlobal().info("item: "+(System.currentTimeMillis()-start));
 
-        posePacket.getWatchableCollectionModifier().write(0,watcher.getWatchableObjects());
 //Logger.getGlobal().info("Bone creation: "+(System.currentTimeMillis()-start));
+    }
+
+    @Override
+    protected PacketContainer createHeadPosePacket(WrappedDataWatcher dataWatcher) {
+        PacketContainer packet = super.createHeadPosePacket(dataWatcher);
+
+        WrappedDataWatcher.WrappedDataWatcherObject invisibility = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ENTITY_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
+        dataWatcher.setObject(invisibility, Byte.decode("0x20"),false);
+        WrappedDataWatcher.WrappedDataWatcherObject silent = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ENTITY_SILENT,WrappedDataWatcher.Registry.get(Boolean.class));
+        dataWatcher.setObject(silent, true,false);
+        WrappedDataWatcher.WrappedDataWatcherObject gravity = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ENTITY_NO_GRAVITY,WrappedDataWatcher.Registry.get(Boolean.class));
+        dataWatcher.setObject(gravity, false,false);
+        WrappedDataWatcher.WrappedDataWatcherObject base = new WrappedDataWatcher
+                .WrappedDataWatcherObject(EntityMeta.ARMOR_STAND_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
+        dataWatcher.setObject(base, Byte.decode("0x08"),false);
+
+        return packet;
     }
 
     @Override
     public void update() {
         if(bone.isHasHeadPoseUpdate()) {
-            writeHeadPose(watcher);
-            posePacket.getWatchableCollectionModifier().write(0,watcher.getWatchableObjects());
+            updateHeadPose(getHeadPose());
         }
 
         if(bone.isHasItemUpdate()) {
             writeHeadItem();
         }
-    }
-
-    protected void writeInit(WrappedDataWatcher watcher) {
-        WrappedDataWatcher.WrappedDataWatcherObject invisibility = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ENTITY_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
-        watcher.setObject(invisibility, Byte.decode("0x20"),false);
-        WrappedDataWatcher.WrappedDataWatcherObject silent = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ENTITY_SILENT,WrappedDataWatcher.Registry.get(Boolean.class));
-        watcher.setObject(silent, true,false);
-        WrappedDataWatcher.WrappedDataWatcherObject gravity = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ENTITY_NO_GRAVITY,WrappedDataWatcher.Registry.get(Boolean.class));
-        watcher.setObject(gravity, false,false);
-        WrappedDataWatcher.WrappedDataWatcherObject base = new WrappedDataWatcher
-                .WrappedDataWatcherObject(EntityMeta.ARMOR_STAND_STATUS,WrappedDataWatcher.Registry.get(Byte.class));
-        watcher.setObject(base, Byte.decode("0x08"),false);
     }
 
     @Override

--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Player;
 public class BoneInitPacket extends BoneMetaPacket {
 
     public BoneInitPacket(Bone bone) {
-        super(bone,0);
+        super(bone);
 
 //long start = System.currentTimeMillis();
 
@@ -40,18 +40,8 @@ public class BoneInitPacket extends BoneMetaPacket {
     }
 
     @Override
-    public void update() {
-        if(bone.isHasHeadPoseUpdate()) {
-            updateHeadPose(getHeadPose());
-        }
-
-        if(bone.isHasItemUpdate()) {
-            writeHeadItem();
-        }
-    }
-
-    @Override
     public void send(Player recipient) {
+        // Override super to unconditionally send out packets - these are used to spawn the entity in
         send(posePacket, recipient);
         send(equipPacket, recipient);
 //Logger.getGlobal().info("send bone init to "+recipient.getName()+" with id: "+bone.getEntityId());

--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/CompositeEntityMovePacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/CompositeEntityMovePacket.java
@@ -1,10 +1,10 @@
 package com.mcmiddleearth.entities.protocol.packets.composite;
 
 import com.mcmiddleearth.entities.entities.composite.CompositeEntity;
-import com.mcmiddleearth.entities.protocol.packets.AbstractPacket;
+import com.mcmiddleearth.entities.protocol.packets.AbstractMovePacket;
 import org.bukkit.entity.Player;
 
-public class CompositeEntityMovePacket extends AbstractPacket {
+public class CompositeEntityMovePacket extends AbstractMovePacket {
 
     private final CompositeEntity entity;
 
@@ -22,5 +22,10 @@ public class CompositeEntityMovePacket extends AbstractPacket {
     public void update() {
         entity.getBones().forEach(bone -> bone.getMovePacket().update());
         entity.getBones().forEach(bone -> bone.getMetaPacket().update());
+    }
+
+    @Override
+    public void markMovementDirty(MoveType moveType) {
+        // NOOP: composite entities know better when their packets need to be updates
     }
 }


### PR DESCRIPTION
Fixes #8. Marked as draft due to dependency on #9.

Moves all logic requiring updates every tick out of the packet code. This allows deferring the relatively expensive updates of the ProtocolLib packet data until the packet is about to be sent to players.

"Stateless" is technically not an entirely accurate term, as the packets still hold some state in the form of the update and resend flags. Still, this PR makes the behavior of packet classes predictable and independent of external state.