### PR TITLE
Fix invalid description of /vtag command definition

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,7 +24,7 @@ commands:
     permission: mcmeentities.developer
     usage: /animation
   vtag:
-    description: : add bukkit like tags to mcme-entities (virtual entities and players)
+    description: add bukkit like tags to mcme-entities (virtual entities and players)
     permission: mcmeentities.user
     usage: /vtag <name> add | remove <tag>
   vspawn:


### PR DESCRIPTION
```
[02:36:24 ERROR]: Could not load 'plugins/MCME-Entities.jar' in folder 'plugins'
org.bukkit.plugin.InvalidDescriptionException: Invalid plugin.yml
        at org.bukkit.plugin.java.JavaPluginLoader.getPluginDescription(JavaPluginLoader.java:188) ~[paper-api-1.18.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.loadPlugins(SimplePluginManager.java:159) ~[paper-api-1.18.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_18_R2.CraftServer.loadPlugins(CraftServer.java:418) ~[paper-1.18.2.jar:git-Paper-317]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:288) ~[paper-1.18.2.jar:git-Paper-317]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1163) ~[paper-1.18.2.jar:git-Paper-317]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.18.2.jar:git-Paper-317]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.yaml.snakeyaml.scanner.ScannerException: mapping values are not allowed here
 in 'reader', line 27, column 18:
        description: : add bukkit like tags to mcme-e ... 
                     ^

```